### PR TITLE
fix tests

### DIFF
--- a/{{cookiecutter.project_name}}/jest.config.js
+++ b/{{cookiecutter.project_name}}/jest.config.js
@@ -1,3 +1,4 @@
+// jest.config.js
 module.exports = {
   moduleNameMapper: {
     // map static asset imports to a stub file under the assumption they are not important to our tests
@@ -9,10 +10,16 @@ module.exports = {
       "<rootDir>/node_modules/@cortexapps/plugin-core/dist/components.cjs.js",
     "@cortexapps/plugin-core":
       "<rootDir>/node_modules/@cortexapps/plugin-core/dist/index.cjs.js",
+    "@cortexapps/react-plugin-ui":
+      "<rootDir>/node_modules/@cortexapps/react-plugin-ui/dist/index.js",
   },
   setupFilesAfterEnv: ["<rootDir>/setupTests.ts"],
   testEnvironment: "jsdom",
+  transformIgnorePatterns: [
+    // @cortexapps/react-plugin-ui is ESM, transform it to CJS
+    "/node_modules/(?!(?:@cortexapps/react-plugin-ui)/)"
+  ],
   transform: {
-    "^.+\\.tsx?$": "babel-jest",
+    "^.+\\.[tj]sx?$": "babel-jest",
   },
 };

--- a/{{cookiecutter.project_name}}/src/components/App.test.tsx
+++ b/{{cookiecutter.project_name}}/src/components/App.test.tsx
@@ -4,17 +4,15 @@ import App from "./App";
 
 describe("App", () => {
   it("shows default tab", async () => {
-    const { getByText, debug } = render(<App />);
+    const { getByText } = render(<App />);
 
     await waitFor(() => {
-      expect(getByText(/This is a helpful caption/)).toBeInTheDocument();
+      expect(getByText(/Accept terms and conditions/)).toBeInTheDocument();
     });
-
-    debug();
   });
 
   it("loads content and changes URL when tab is changed", async () => {
-    const { getByText, debug } = render(<App />);
+    const { getByText } = render(<App />);
 
     await waitFor(() => {
       expect(window.location.href).toContain("basic");
@@ -28,19 +26,16 @@ describe("App", () => {
       expect(getByText(/Below is the plugin context object/)).toBeInTheDocument();
       expect(window.location.href).toContain("context");
     });
-    debug();
   });
 
   it("loads deeplinked tab", async () => {
     // Set the URL to the "colors" tab.
     window.history.pushState({}, "Test page", "/?examplePluginRoute=/colors");
 
-    const { getByText, debug } = render(<App />);
+    const { getByText } = render(<App />);
 
     await waitFor(() => {
       expect(getByText(/Theme variable swatches/)).toBeInTheDocument();
     });
-
-    debug();
   });
 });


### PR DESCRIPTION
react-plugin-ui seems to be ESM, which Jest doesn't like. This PR is to make Jest transform it to CJS so that the tests will run

Also slightly updated the tests for new content and to remove debug output