### PR TITLE
Fix iframe resizer

### DIFF
--- a/{{cookiecutter.project_name}}/package.json
+++ b/{{cookiecutter.project_name}}/package.json
@@ -3,6 +3,7 @@
   "version": "{{cookiecutter.version}}",
   "license": "{{cookiecutter.license}}",
   "dependencies": {
+    "@iframe-resizer/child": "^5.4.4",
     "@tanstack/react-query": "^5.69.0",
     "@tanstack/react-query-devtools": "^5.69.0",
     "react": "^18.2.0",
@@ -10,7 +11,6 @@
     "react-router-dom": "^7.4.0"
   },
   "devDependencies": {
-    "clsx": "^2.1.1",
     "@babel/core": "^7.21.3",
     "@babel/plugin-syntax-jsx": "^7.18.6",
     "@babel/preset-env": "^7.20.2",
@@ -28,6 +28,7 @@
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.55.0",
     "babel-jest": "^29.5.0",
+    "clsx": "^2.1.1",
     "css-loader": "^6.7.3",
     "eslint": "^8.0.1",
     "eslint-config-prettier": "^8.7.0",

--- a/{{cookiecutter.project_name}}/src/index.html
+++ b/{{cookiecutter.project_name}}/src/index.html
@@ -1,10 +1,3 @@
 <html>
-  <head>
-    <!-- <script
-      defer
-      type="text/javascript"
-      src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child"
-    ></script> -->
-  </head>
   <div id="cortex-plugin-root"></div>
 </html>

--- a/{{cookiecutter.project_name}}/src/index.tsx
+++ b/{{cookiecutter.project_name}}/src/index.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from "react-dom/client";
+import "@iframe-resizer/child";
 import App from "./components/App";
 import { CortexApi } from "@cortexapps/plugin-core";
 


### PR DESCRIPTION
old plugin template was loading iframe-resizer child from jsdelivr, that wouldn't work in all environments, and the script tag had gotten commented out from index.html. This PR adds @iframe-resizer/child to node_modules and imports it in index.tsx so that it will work without access to jsdelivr